### PR TITLE
Log exception if it arises in exists? method

### DIFF
--- a/lib/paperclip/storage/gcs.rb
+++ b/lib/paperclip/storage/gcs.rb
@@ -61,7 +61,8 @@ module Paperclip
         else
           false
         end
-      rescue
+      rescue => e
+        log ("#{e.class} in exists?: #{e.message}")
         false
       end
 


### PR DESCRIPTION
Not sure how to test this within Rotor quite yet... but the silent exception cost me a chunk of debugging time..!

Maybe it would be better to propagate the exception and let the caller deal with it?  In the case I just had, it was due to a misconfiguration, so it shouldn't have been swallowed at all...