### PR TITLE
GCS - don't catch exceptions in 'exists?'

### DIFF
--- a/lib/paperclip/storage/gcs.rb
+++ b/lib/paperclip/storage/gcs.rb
@@ -61,8 +61,6 @@ module Paperclip
         else
           false
         end
-      rescue
-        false
       end
 
       def flush_writes


### PR DESCRIPTION
I think it makes more sense for the client to know about them.  An exception will either be due to a misconfiguration or credentials problem, which means no request will work and the app needs to be fixed, or else an intermittent network issue, which the client should be permitted to retry (if we see a lot of retries logged from the app, we might eventually put the exception-specific rescue back in here with some retry logic).